### PR TITLE
Chapter 3.7 Advanced testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /log/*
 !/log/.keep
 /tmp
+
+# Ignore Spring files.
+/spring/*.pid

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :test do
   gem 'minitest-reporters', '1.0.5'
   gem 'mini_backtrace',     '0.1.3'
   gem 'guard-minitest',     '2.3.1'
+  gem 'terminal-notifier'
+  gem 'terminal-notifier-guard'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem 'minitest-reporters', '1.0.5'
   gem 'mini_backtrace',     '0.1.3'
   gem 'guard-minitest',     '2.3.1'
+  gem 'guard-livereload'
   gem 'terminal-notifier'
   gem 'terminal-notifier-guard'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,11 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    eventmachine (1.2.0.1)
     execjs (2.7.0)
     ffi (1.9.10)
     formatador (0.2.5)
@@ -67,9 +71,16 @@ GEM
       pry (>= 0.9.12)
       shellany (~> 0.0)
       thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-livereload (2.5.2)
+      em-websocket (~> 0.5)
+      guard (~> 2.8)
+      guard-compat (~> 1.0)
+      multi_json (~> 1.8)
     guard-minitest (2.3.1)
       guard (~> 2.0)
       minitest (>= 3.0)
+    http_parser.rb (0.6.0)
     i18n (0.7.0)
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -200,6 +211,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
+  guard-livereload
   guard-minitest (= 2.3.1)
   jbuilder (~> 2.0)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    terminal-notifier (1.6.3)
+    terminal-notifier-guard (1.7.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -210,6 +212,8 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   sqlite3
+  terminal-notifier
+  terminal-notifier-guard
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,71 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+guard :minitest, spring: true, all_on_start: false do
+  watch(%r{^test/(.*)/?(.*)_test\.rb$})
+  watch('test/test_helper.rb') { 'test' }
+  watch('config/routes.rb')    { integration_tests }
+  watch(%r{^app/models/(.*?)\.rb$}) do |matches|
+    "test/models/#{matches[1]}_test.rb"
+  end
+  watch(%r{^app/controllers/(.*?)_controller\.rb$}) do |matches|
+    resource_tests(matches[1])
+  end
+  watch(%r{^app/views/([^/]*?)/.*\.html\.erb$}) do |matches|
+    ["test/controllers/#{matches[1]}_controller_test.rb"] +
+    integration_tests(matches[1])
+  end
+  watch(%r{^app/helpers/(.*?)_helper\.rb$}) do |matches|
+    integration_tests(matches[1])
+  end
+  watch('app/views/layouts/application.html.erb') do
+    'test/integration/site_layout_test.rb'
+  end
+  watch('app/helpers/sessions_helper.rb') do
+    integration_tests << 'test/helpers/sessions_helper_test.rb'
+  end
+  watch('app/controllers/sessions_controller.rb') do
+    ['test/controllers/sessions_controller_test.rb',
+     'test/integration/users_login_test.rb']
+  end
+  watch('app/controllers/account_activations_controller.rb') do
+    'test/integration/users_signup_test.rb'
+  end
+  watch(%r{app/views/users/*}) do
+    resource_tests('users') +
+    ['test/integration/microposts_interface_test.rb']
+  end
+end
+
+# Returns the integration tests corresponding to the given resource.
+def integration_tests(resource = :all)
+  if resource == :all
+    Dir["test/integration/*"]
+  else
+    Dir["test/integration/#{resource}_*.rb"]
+  end
+end
+
+# Returns the controller tests corresponding to the given resource.
+def controller_test(resource)
+  "test/controllers/#{resource}_controller_test.rb"
+end
+
+# Returns all tests for the given resource.
+def resource_tests(resource)
+  integration_tests(resource) << controller_test(resource)
+end

--- a/Guardfile
+++ b/Guardfile
@@ -15,6 +15,45 @@
 #
 # and, you'll have to watch "config/Guardfile" instead of "Guardfile"
 
+guard 'livereload' do
+  extensions = {
+    css: :css,
+    scss: :css,
+    sass: :css,
+    js: :js,
+    coffee: :js,
+    html: :html,
+    png: :png,
+    gif: :gif,
+    jpg: :jpg,
+    jpeg: :jpeg,
+    # less: :less, # uncomment if you want LESS stylesheets done in browser
+  }
+
+  rails_view_exts = %w(erb haml slim)
+
+  # file types LiveReload may optimize refresh for
+  compiled_exts = extensions.values.uniq
+  watch(%r{public/.+\.(#{compiled_exts * '|'})})
+
+  extensions.each do |ext, type|
+    watch(%r{
+          (?:app|vendor)
+          (?:/assets/\w+/(?<path>[^.]+) # path+base without extension
+           (?<ext>\.#{ext})) # matching extension (must be first encountered)
+          (?:\.\w+|$) # other extensions
+          }x) do |m|
+      path = m[1]
+      "/assets/#{path}.#{type}"
+    end
+  end
+
+  # file needing a full reload of the page anyway
+  watch(%r{app/views/.+\.(#{rails_view_exts * '|'})$})
+  watch(%r{app/helpers/.+\.rb})
+  watch(%r{config/locales/.+\.yml})
+end
+
 guard :minitest, spring: true, all_on_start: false do
   watch(%r{^test/(.*)/?(.*)_test\.rb$})
   watch('test/test_helper.rb') { 'test' }

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -2,6 +2,7 @@
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
+Rails.backtrace_cleaner.add_silencer { |line| line =~ /rvm/ }
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require "minitest/reporters"
+Minitest::Reporters.use!
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
先にテストのセットアップをやった
- Exの前にAdvanced testing setupをやった
  - minitest-reportersを設定
    - テストのレポートがいい感じになる
  - backtrace_silencerを設定
    - rvm用の設定ぽいから不要かも
  - Guardを設定
    - ファイルを変更するたびに自動的にテストを実行できるぞ
  - Springのpidファイルを.gitignoreに追加
- ついでにやった
  - terminal-notifier-guardでテスト結果を通知する
  - guard-livereloadで自動リロードする
