### PR TITLE
Chapter 6 Modeling users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Unicorn as the app server
 # gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     arel (6.0.3)
+    bcrypt (3.1.7)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.2.0.0)
@@ -211,6 +212,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootstrap-sass (= 3.2.0.0)
   byebug
   coffee-rails (~> 4.1.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
   validates :name, presence: true, length: { maximum: 50 }
-  validates :email, presence: true, length: { maximum: 255 }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, length: { maximum: 255 },
+                    format: { with: VALID_EMAIL_REGEX }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,4 @@
 class User < ActiveRecord::Base
+  validates :name, presence: true
+  validates :email, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
+  before_save { self.email = email.downcase }
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  before_save { self.email = email.downcase }
+  before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ActiveRecord::Base
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
+  validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
 class User < ActiveRecord::Base
-  validates :name, presence: true
-  validates :email, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, length: { maximum: 255 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ActiveRecord::Base
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
+  has_secure_password
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,6 @@ class User < ActiveRecord::Base
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
-                    format: { with: VALID_EMAIL_REGEX }
+                    format: { with: VALID_EMAIL_REGEX },
+                    uniqueness: { case_sensitive: false }
 end

--- a/db/migrate/20160621062141_create_users.rb
+++ b/db/migrate/20160621062141_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160622055933_add_index_to_users_email.rb
+++ b/db/migrate/20160622055933_add_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersEmail < ActiveRecord::Migration
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20160622064053_add_password_digest_to_users.rb
+++ b/db/migrate/20160622064053_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160621062141) do
+
+  create_table "users", force: :cascade do |t|
+    t.string   "name"
+    t.string   "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622055933) do
+ActiveRecord::Schema.define(version: 20160622064053) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.string   "password_digest"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621062141) do
+ActiveRecord::Schema.define(version: 20160622055933) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -19,5 +19,7 @@ ActiveRecord::Schema.define(version: 20160621062141) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,1 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  name: MyString
-  email: MyString
-
-two:
-  name: MyString
-  email: MyString

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+
+two:
+  name: MyString
+  email: MyString

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -46,4 +46,11 @@ class UserTest < ActiveSupport::TestCase
       assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"
     end
   end
+
+  test "email addresses should be unique" do
+    duplicate_user = @user.dup
+    duplicate_user.email = @user.email.upcase
+    @user.save
+    assert_not duplicate_user.valid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = User.new(name: "Example User", email: "user@example.com")
+    @user = User.new(name: "Example User", email: "user@example.com",
+                     password: "foobar", password_confirmation: "foobar")
   end
 
   test "should be valid" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -41,7 +41,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "email validation should reject invalid addresses" do
     invalid_addresses = %w[user@example,com user_at_foo.org user.name@example.
-                           foo@bar_baz.com foo@bar+baz.com]
+                           foo@bar_baz.com foo@bar+baz.com foo@bar..com]
     invalid_addresses.each do |invalid_address|
       @user.email = invalid_address
       assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,21 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @user = User.new(name: "Example User", email: "user@example.com")
+  end
+
+  test "should be valid" do
+    assert @user.valid?
+  end
+
+  test "name should be present" do
+    @user.name = "     "
+    assert_not @user.valid?
+  end
+
+  test "email should be present" do
+    @user.email = "     "
+    assert_not @user.valid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -55,6 +55,14 @@ class UserTest < ActiveSupport::TestCase
     assert_not duplicate_user.valid?
   end
 
+  test "email addresses should be saved as lower-case" do
+    mixed_case_email = "Foo@ExAMPle.CoM"
+    @user.email = mixed_case_email
+    @user.save
+    # @user.reloadでDBから読み込み直す（DBと一致していることを保証する）
+    assert_equal mixed_case_email.downcase, @user.reload.email
+  end
+
   test "password should be present (nonblank)" do
     # 空白だったら6文字以上でも不可
     @user.password = @user.password_confirmation = " " * 6

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -18,4 +18,14 @@ class UserTest < ActiveSupport::TestCase
     @user.email = "     "
     assert_not @user.valid?
   end
+
+  test "name should not be too long" do
+    @user.name = "a" * 51
+    assert_not @user.valid?
+  end
+
+  test "email should not be too long" do
+    @user.email = "a" * 244 + "@example.com" #=> 256
+    assert_not @user.valid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -28,4 +28,22 @@ class UserTest < ActiveSupport::TestCase
     @user.email = "a" * 244 + "@example.com" #=> 256
     assert_not @user.valid?
   end
+
+  test "email validation should accept valid addresses" do
+    valid_addresses = %w[user@example.com USER@foo.COM A_US-ER@foo.bar.org
+                         first.last@foo.jp alice+bob@baz.cn]
+    valid_addresses.each do |valid_address|
+      @user.email = valid_address
+      assert @user.valid?, "#{valid_address.inspect} should be valid"
+    end
+  end
+
+  test "email validation should reject invalid addresses" do
+    invalid_addresses = %w[user@example,com user_at_foo.org user.name@example.
+                           foo@bar_baz.com foo@bar+baz.com]
+    invalid_addresses.each do |invalid_address|
+      @user.email = invalid_address
+      assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -54,4 +54,16 @@ class UserTest < ActiveSupport::TestCase
     @user.save
     assert_not duplicate_user.valid?
   end
+
+  test "password should be present (nonblank)" do
+    # 空白だったら6文字以上でも不可
+    @user.password = @user.password_confirmation = " " * 6
+    assert_not @user.valid?
+  end
+
+  test "password should have a minimum length" do
+    # 6文字未満は不可
+    @user.password = @user.password_confirmation = "a" * 5
+    assert_not @user.valid?
+  end
 end


### PR DESCRIPTION
半分まできたぞ〜

---
- Index: #2
- Chapter 1: #6 
- Chapter 2: #7
- Chapter 3: #8 #10 
- Chapter 4: #11
- Chapter 5: #12 #14 
- Chapter 6: #17 #19 
- Chapter 7: #20

---
# Chapter 6 Modeling users
- サインアップページ作りかけにしてたから作っていくぜ
- ログインやパスワードリセットなどもやっていく
- ユーザーモデル
  - ActiveRecord
  - `name`と`email`の2つの属性をもつ
  - Ch5でUsersコントローラーを作ったので、今度はモデルをつくる
    - `rails generate model User name:string email:string`
  - Usersコントローラー、Userモデル
- マイグレーションファイル
  - データベース構造を逐次変更するための手段を提供
  - プリフィックスは日付：最初の頃は数値だったが、コンフリクトするので
  - `change`メソッド
  - `create_table`メソッドのブロックで作成するカラムを示す
  -  > Here the table name is plural (users) even though the model name is singular (User), which reflects a linguistic convention followed by Rails: a model represents a single user, whereas a database table consists of many users
  - テーブル名は複数形で、モデルは単数形
  - モデルは単一のuserを表し、一方でデータベーステーブルは多くのユーザーから成り立っている
  - `t.timestamps`：作成日時と更新日時を自動的に記録する
  - マイグレーションを実行：`rake db:migrate`
  - `rake db:rollback`で戻せる
    - この例の場合、`drop_table`が実行される
    - `change`メソッドは`create_table`の逆が`drop_table`になると知っている
    - 元に戻せない変更をする場合、`up`と`down`メソッドをそれぞれ定義する必要がある
- モデルファイル
  - マイグレーション
    - `development.sqlite3`データベースに
    - `users`テーブルが作成され、
    - `id`, `name`, `email`, `created_at`, `updated_at`カラムをもつ
  - モデルファイルを見てみよう `app/models/user.rb`
  - `ActiveRecord::Base`クラスを継承
- `rails console --sandbox`で色々試してみよう
  - 終了時にすべての変更がロールバックされる便利なオプション
  - `user = User.new(name: "Michael Hartl", email: "mhartl@example.com")`
  - `User.new`はメモリ上にオブジェクトを作成するだけ
  - `User#save`メソッドでデータベースに保存される
    - 対応するSQLが発行される（`INSERT INTO "users"...`）
  - `user.name`でname属性にアクセス
  - `User.create`メソッドは作成と保存を同時に行える
    - `foo = User.create(name: "Foo", email: "foo@bar.com")`
  - `User#destroy`で削除
    - `foo.destroy`
  - `User.find(1)` idが1のユーザーを取得
    - 存在しない場合例外を出す
  - 任意の属性で検索する：`User.find_by(email: "mhartl@example.com")`
  - 最初のひとり：`User.first`、すべて取得：`User.all`
  - `User#reload`でデータベースから読み込み直す（保存しない）
  - 複数の属性を更新して保存する：`update_attributes`
    - `user.update_attributes(name: "The Dude", email: "dude@abides.org")`
  - いずれかのバリデーションが失敗したとき（例えば、6.3で実装するような保存するためにパスワードを要求する場合）は`update_attributes`は失敗するので注意
  - `update_attribute`はこの制限をバイパスする
    - `user.update_attribute(:name, "The Dude")`
- バリデーション
  - 初期状態だとnameやemailが空でも受け付けてしまう
  - バリデーションしましょう
  - TDDでやっていく：`test/models/user_test.rb`
  - `setup`メソッドでテスト前に毎回`@user`を用意する
  - `assert @user.valid?`
  - nameが空（空白文字列）だと作成できないようにする
    - `validates :name, presence: true`
  - テストが通り、空（空白文字列）だと作成できないようになったことを確認できた
- 長さのバリデーション
  - nameは50文字、emailは255文字までに制限する
  - `length: { maximum: 50 }`
- フォーマットのバリデーション
  - nameは空でなく50文字までという最低限の制約
  - だが、emailは有効なメールアドレスという厳しい制約がある
  - まず有効なメールアドレスと無効なアドレスのリストをつくってテストを書く
  - フォーマットバリデーション：`format: { with: /<regular expression>/ }`
  - regular expression：正規表現
  - `VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i`
  - [`\A`と`\z`ってなに](https://github.com/shimoju/rails-tutorial/issues/5#issuecomment-227645929)
  - [Rubular](http://www.rubular.com/)で試してみよう
  - `format: { with: VALID_EMAIL_REGEX }`でバリデーションを設定
  - この正規表現だと連続ドットが通ってしまう：エクササイズでやるよ
- ユニーク（一意）バリデーション
  - 同じメールアドレスで登録できないようにしたい→ユニークバリデーション
  - 複製をつくって（同じ属性をもつ）、1人目を保存し、2人目でバリデーションエラーが出る、というテストを書く
  - `uniqueness: true`
  - とりあえずできたが、メールアドレスは大文字小文字を区別しない
    - 複製したユーザーのemailを大文字にしてみる（`upcase`）→テストが失敗してしまう
  - 区別しないようにする：`uniqueness: { case_sensitive: false }`
  - ただし問題が：データベースレベルで一意性を保証するものではない
  - 例えば、ユーザー登録ボタンを誤って2回連続で押してしまったとき、ユーザーがDBに保存される前（メモリ上にあるとき）に2回目のリクエストがくると、バリデーションを通過してしまう
  - モデルレベルだけでなく、データベースレベルでユニーク制約をかける必要がある
  - データベースにインデックスをつくりましょう
    - マイグレーションに`add_index :users, :email, unique: true`
  - fixtureでエラーが出るので、空にしておく
  - 大文字小文字を区別するデータベースがあるので、必ず小文字にして保存するようにして回避しよう
  - `before_save { self.email = email.downcase }`
    - `before_save`コールバック：保存する前に呼び出されるメソッド
- セキュアなパスワードを追加する
  - ハッシュされたパスワードを保存する
    - RubyのHashではなく、一方向ハッシュ関数のこと
  - ユーザーはパスワードを打ち込んで送信する→それをハッシュ化→データベースにあるハッシュと比較→一致していたらパスワードが正しい→認証
  - パスワードを直接保存しないのでセキュアになる
  - `has_secure_password`をモデルに追加
    - ハッシュされたパスワードを保存する`password_digest`属性
    - 仮想の属性`password`と`password_confirmation`が追加されて、入力された2つが一致していないとバリデーションが通らなくなる
    - パスワードが正しいとき、そのユーザーを返す`authenticate`メソッド
  - `password_digest`カラムをデータベースに追加しよう
    - `rails generate migration add_password_digest_to_users password_digest:string`
    - このようにマイグレーションを作ると、`add_culumn`メソッドを自動的に生成してくれる
  - `has_secure_password`ではbcrypt gemを使用しているのでGemfileに追加する
  - `has_secure_password`をモデルに追加すると、テストが失敗するようになる→テスト内にパスワードを追加する
- パスワードの最小文字数を制限する
  - nameと同様に`presence`と`length`でバリデーション
  - `validates :password, presence: true, length: { minimum: 6 }`
- これで、パスワードを設定できるようになった
  - まだWeb上からはサインアップできない→Ch7でやっていく
  - `rails console`でユーザーを作成してみる
  - `user.password_digest #=> "$2a$10$YmQTuuDNOszvu5yi7auOC.F4G//FGhyQSWCpghqRWQWITUYlG3XVy"`
    - ハッシュされている
  - `authenticate`メソッド
    - `user.authenticate("foobaz") #=> false`
    - `user.authenticate("foobar") #=> #<User id: 1, name:...`
    - パスワードが間違っていたら`false`を返し、正しければそのユーザー（自身）を返す
    - 実際のところは自身のオブジェクトが返ってくることはあまり重要ではない：`true`と評価される値であること
    - `!!user.authenticate("foobar")`こうすれば必ず`true`か`false`が返る
- 次からはサインアップフォームやユーザー情報をWebから表示できるようにしていくよ
