### PR TITLE
CI環境のデータベースをPostgreSQLに切り替える

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
 rvm:
   - 2.3.1
-bundler_args: --without development production --deployment --jobs=3 --retry=3
+services:
+  - postgresql
+bundler_args: --without development --deployment --jobs=3 --retry=3
 cache: bundler
 before_script:
+  - cp config/database.travis.yml config/database.yml
   - bin/rake db:setup
 notifications:
   slack:

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,6 @@
+test:
+  adapter: postgresql
+  pool: 5
+  timeout: 5000
+  username: postgres
+  database: travis_ci_test


### PR DESCRIPTION
CIの環境はできる限りプロダクションと合わせた方がいいので、
SQLiteからPostgreSQLに切り替えよう

実際のテストがあるChapter6 #17 のマージ後くらいにやりましょう

参考：https://github.com/Asuforce/rails_tutorial/blob/master/.travis.yml
