### PR TITLE
Chapter 6 Exercises

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  before_save { self.email = email.downcase }
+  before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -41,7 +41,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "email validation should reject invalid addresses" do
     invalid_addresses = %w[user@example,com user_at_foo.org user.name@example.
-                           foo@bar_baz.com foo@bar+baz.com]
+                           foo@bar_baz.com foo@bar+baz.com foo@bar..com]
     invalid_addresses.each do |invalid_address|
       @user.email = invalid_address
       assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -55,6 +55,14 @@ class UserTest < ActiveSupport::TestCase
     assert_not duplicate_user.valid?
   end
 
+  test "email addresses should be saved as lower-case" do
+    mixed_case_email = "Foo@ExAMPle.CoM"
+    @user.email = mixed_case_email
+    @user.save
+    # @user.reloadでDBから読み込み直す（DBと一致していることを保証する）
+    assert_equal mixed_case_email.downcase, @user.reload.email
+  end
+
   test "password should be present (nonblank)" do
     # 空白だったら6文字以上でも不可
     @user.password = @user.password_confirmation = " " * 6


### PR DESCRIPTION
1. emailが小文字になって保存されていることを確認するテストを追加する。そして`before_save`コールバックをコメントアウトしたらテストが失敗し、戻すとテストが成功することを確認する
2. `before_save { email.downcase! }`と変更し、`downcase!`(“bang” method)を使ってemail属性を直接変更しても問題ないかをテストで確認する
3. 先にも言ったとおり、メールアドレスの連続ドットが通っちゃうバグがある。テストのinvalidアドレスのリストに連続ドットのメアド`foo@bar..com`を追加したらテストが失敗し、下のより複雑な正規表現を使うとテストが通ることを確認する
