### PR TITLE
Chapter 7 Exercises

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,8 +1,9 @@
 module UsersHelper
   # Returns the Gravatar for the given user.
-  def gravatar_for(user)
+  def gravatar_for(user, options = { size: 80 })
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    size = options[:size]
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: "gravatar")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <%= render 'layouts/header' %>
   <div class="container">
     <% flash.each do |message_type, message| %>
-      <div class="alert alert-<%= message_type %>"><%= message %></div>
+      <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
     <% end %>
     <%= yield %>
     <%= render 'layouts/footer' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
   <aside class="col-md-4">
     <section class="user_info">
       <h1>
-        <%= gravatar_for @user %>
+        <%= gravatar_for @user, size: 200 %>
         <%= @user.name %>
       </h1>
     </section>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -13,6 +13,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     # サインアップが失敗したとき、再度`users/new`がレンダリングされることをテスト
     assert_template 'users/new'
+    assert_select 'div#error_explanation'
+    assert_select 'div.field_with_errors'
   end
 
   test "valid signup information" do

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -29,5 +29,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     # リダイレクトしたら`users/show`＝プロフィールページがレンダリングされること
     assert_template 'users/show'
+    assert_not flash.empty?
   end
 end


### PR DESCRIPTION
**こいつもマージしない**
1. `gravatar_for`ヘルパーに`size`パラメータを追加して、プロフィール画像のサイズを変更できることを確認する
2. 無効な情報でサインアップしたときのエラーメッセージがきちんと表示されているか`assert_select`でテストする
3. ウェルカムメッセージのflashが空でないかテストする（テストが壊れやすくなるのでテキストまでテストする必要はない）
4. flashを出力するHTMLが汚いので、`content_tag`ヘルパーで書きなおして、テストが通ることを確認する
