### PR TITLE
Chapter 8 Log in, log out

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require bootstrap
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/sessions.coffee
+++ b/app/assets/javascripts/sessions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -167,6 +167,20 @@ input {
   }
 }
 
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}
+
 /* miscellaneous */
 
 .debug_dump {

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,5 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
-  def hello
-    render text: 'hello, world!'
-  end
+  include SessionsHelper
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,5 +16,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    log_out
+    redirect_to root_url
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       # Log the user in and redirect to the user's show page.
     else
-      # Create an error message.
+      flash.now[:danger] = 'Invalid email/password combination'
       render 'new'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,7 @@ class SessionsController < ApplicationController
     # ユーザーが存在し、かつパスワードが正しければ認証OK
     if user && user.authenticate(params[:session][:password])
       log_in user
+      remember user
       redirect_to user
     else
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
     # ユーザーが存在し、かつパスワードが正しければ認証OK
     if user && user.authenticate(params[:session][:password])
       log_in user
-      remember user
+      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
       redirect_to user
     else
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,19 @@
 class SessionsController < ApplicationController
   def new
   end
+
+  def create
+    # `find_by(email:)`でメールアドレスからユーザーを検索
+    user = User.find_by(email: params[:session][:email].downcase)
+    # ユーザーが存在し、かつパスワードが正しければ認証OK
+    if user && user.authenticate(params[:session][:password])
+      # Log the user in and redirect to the user's show page.
+    else
+      # Create an error message.
+      render 'new'
+    end
+  end
+
+  def destroy
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,8 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     # ユーザーが存在し、かつパスワードが正しければ認証OK
     if user && user.authenticate(params[:session][:password])
-      # Log the user in and redirect to the user's show page.
+      log_in user
+      redirect_to user
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      log_in @user
       flash[:success] = "Welcome to the Sample App!"
       redirect_to @user # == redirect_to user_url(@user)
     else

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -13,4 +13,10 @@ module SessionsHelper
   def logged_in?
     !current_user.nil?
   end
+
+  # Logs out the current user.
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,2 +1,6 @@
 module SessionsHelper
+  # Logs in the given user.
+  def log_in(user)
+    session[:user_id] = user.id
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -8,4 +8,9 @@ module SessionsHelper
   def current_user
     @current_user ||= User.find_by(id: session[:user_id])
   end
+
+  # Returns true if the user is logged in, false otherwise.
+  def logged_in?
+    !current_user.nil?
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -4,6 +4,13 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
+  # Remembers a user in a persistent session.
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
   # Returns the current logged-in user (if any).
   def current_user
     @current_user ||= User.find_by(id: session[:user_id])

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -3,4 +3,9 @@ module SessionsHelper
   def log_in(user)
     session[:user_id] = user.id
   end
+
+  # Returns the current logged-in user (if any).
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -29,8 +29,16 @@ module SessionsHelper
     !current_user.nil?
   end
 
+  # Forgets a persistent session.
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   # Logs out the current user.
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -11,9 +11,17 @@ module SessionsHelper
     cookies.permanent[:remember_token] = user.remember_token
   end
 
-  # Returns the current logged-in user (if any).
+  # Returns the user corresponding to the remember token cookie.
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
+    end
   end
 
   # Returns true if the user is logged in, false otherwise.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ActiveRecord::Base
 
   # Returns true if the given token matches the digest.
   def authenticated?(remember_token)
+    return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,9 @@ class User < ActiveRecord::Base
   def authenticated?(remember_token)
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
+
+  # Forgets a user.
+  def forget
+    update_attribute(:remember_digest, nil)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,9 @@ class User < ActiveRecord::Base
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
   end
+
+  # Returns true if the given token matches the digest.
+  def authenticated?(remember_token)
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
+  attr_accessor :remember_token
   before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
@@ -14,5 +15,16 @@ class User < ActiveRecord::Base
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
+  end
+
+  # Returns a random token.
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  # Remembers a user in the database for use in persistent sessions.
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,12 @@ class User < ActiveRecord::Base
                     uniqueness: { case_sensitive: false }
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
+
+  # Returns the hash digest of the given string.
+  def User.digest(string)
+    # 環境に応じてハッシュ値の計算コストを変更する
+    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                  BCrypt::Engine.cost
+    BCrypt::Password.create(string, cost: cost)
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,26 @@
     <%= link_to "sample app", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home",   root_path %></li>
-        <li><%= link_to "Help",   help_path %></li>
-        <li><%= link_to "Log in", '#' %></li>
+        <li><%= link_to "Home", root_path %></li>
+        <li><%= link_to "Help", help_path %></li>
+        <% if logged_in? %>
+          <li><%= link_to "Users", '#' %></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+              Account <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+              <li><%= link_to "Profile", current_user %></li>
+              <li><%= link_to "Settings", '#' %></li>
+              <li class="divider"></li>
+              <li>
+                <%= link_to "Log out", logout_path, method: "delete" %>
+              </li>
+            </ul>
+          </li>
+        <% else %>
+          <li><%= link_to "Log in", login_path %></li>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,2 +1,19 @@
-<h1>Sessions#new</h1>
-<p>Find me in app/views/sessions/new.html.erb</p>
+<% provide(:title, "Log in") %>
+<h1>Log in</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(:session, url: login_path) do |f| %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.submit "Log in", class: "btn btn-primary" %>
+    <% end %>
+
+    <p>New user? <%= link_to "Sign up now!", signup_path %></p>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,6 +11,11 @@
       <%= f.label :password %>
       <%= f.password_field :password, class: 'form-control' %>
 
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+        <%= f.check_box :remember_me %>
+        <span>Remember me on this computer</span>
+      <% end %>
+
       <%= f.submit "Log in", class: "btn btn-primary" %>
     <% end %>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Sessions#new</h1>
+<p>Find me in app/views/sessions/new.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   get 'about' => 'static_pages#about'
   get 'contact' => 'static_pages#contact'
   get 'signup' => 'users#new'
+  get 'login' => 'sessions#new'
+  post 'login' => 'sessions#create'
+  delete 'logout' => 'sessions#destroy'
   resources :users
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20160629062802_add_remember_digest_to_users.rb
+++ b/db/migrate/20160629062802_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622064053) do
+ActiveRecord::Schema.define(version: 20160629062802) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 20160622064053) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.string   "password_digest"
+    t.string   "remember_digest"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class SessionsControllerTest < ActionController::TestCase
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,1 +1,6 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+michael:
+  name: Michael Example
+  email: michael@example.com
+  password_digest: <%= User.digest('password') %>

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+  def setup
+    # fixturesからユーザーmichaelさんを作成
+    @user = users(:michael)
+    # rememberメソッドで覚える
+    remember(@user)
+  end
+
+  # current_userメソッドで返ってくるユーザーが@userと一致していること
+  test "current_user returns right user when session is nil" do
+    assert_equal @user, current_user
+    assert is_logged_in?
+  end
+
+  test "current_user returns nil when remember digest is wrong" do
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+    assert_nil current_user
+  end
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -43,4 +43,15 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+
+  test "login with remembering" do
+    log_in_as(@user, remember_me: '1')
+    # テスト内ではキーにシンボルが使えないので、文字列でアクセスする
+    assert_not_nil cookies['remember_token']
+  end
+
+  test "login without remembering" do
+    log_in_as(@user, remember_me: '0')
+    assert_nil cookies['remember_token']
+  end
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -36,6 +36,8 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
     assert_not is_logged_in?
     assert_redirected_to root_url
+    # Simulate a user clicking logout in a second window.
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path,      count: 0

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -18,9 +18,10 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert flash.empty?
   end
 
-  test "login with valid information" do
+  test "login with valid information followed by logout" do
     get login_path
     post login_path, session: { email: @user.email, password: 'password' }
+    assert is_logged_in?
     # ログインできたらプロフィールページにリダイレクトすること
     assert_redirected_to @user
     # リダイレクトを追う（実際にリダイレクト先ページにアクセスする）
@@ -30,5 +31,14 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", login_path, count: 0
     assert_select "a[href=?]", logout_path
     assert_select "a[href=?]", user_path(@user)
+
+    # logout_pathにDELETEリクエスト→destroyアクション
+    delete logout_path
+    assert_not is_logged_in?
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_select "a[href=?]", login_path
+    assert_select "a[href=?]", logout_path,      count: 0
+    assert_select "a[href=?]", user_path(@user), count: 0
   end
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UsersLoginTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
   # メールアドレス/パスワードが正しくないとき
   test "login with invalid information" do
     get login_path
@@ -12,5 +16,19 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     # 別のページにアクセスするとエラーメッセージが消えていること
     get root_path
     assert flash.empty?
+  end
+
+  test "login with valid information" do
+    get login_path
+    post login_path, session: { email: @user.email, password: 'password' }
+    # ログインできたらプロフィールページにリダイレクトすること
+    assert_redirected_to @user
+    # リダイレクトを追う（実際にリダイレクト先ページにアクセスする）
+    follow_redirect!
+    assert_template 'users/show'
+    # ログインページヘのリンクが存在しない(リンクが0個)こと
+    assert_select "a[href=?]", login_path, count: 0
+    assert_select "a[href=?]", logout_path
+    assert_select "a[href=?]", user_path(@user)
   end
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UsersLoginTest < ActionDispatch::IntegrationTest
+  # メールアドレス/パスワードが正しくないとき
+  test "login with invalid information" do
+    get login_path
+    assert_template 'sessions/new'
+    post login_path, session: { email: "", password: "" }
+    # ログインフォームが表示され、エラーメッセージ(flash)が存在すること
+    assert_template 'sessions/new'
+    assert_not flash.empty?
+    # 別のページにアクセスするとエラーメッセージが消えていること
+    get root_path
+    assert flash.empty?
+  end
+end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -27,5 +27,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     # リダイレクトしたら`users/show`＝プロフィールページがレンダリングされること
     assert_template 'users/show'
+    assert is_logged_in?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -74,4 +74,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = "a" * 5
     assert_not @user.valid?
   end
+
+  test "authenticated? should return false for a user with nil digest" do
+    assert_not @user.authenticated?('')
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,4 +9,9 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+
+  # Returns true if a test user is logged in.
+  def is_logged_in?
+    !session[:user_id].nil?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,4 +14,28 @@ class ActiveSupport::TestCase
   def is_logged_in?
     !session[:user_id].nil?
   end
+
+  # Logs in a test user.
+  def log_in_as(user, options = {})
+    # ハッシュはキーが存在しなければnilが返るので、`|| 'デフォルト値'`と書ける
+    password    = options[:password]    || 'password'
+    remember_me = options[:remember_me] || '1'
+    # インテグレーションテストの場合は（通常のように）postすることでログインし、
+    # そうでない場合はsessionメソッドを直接使ってログインとする
+    if integration_test?
+      post login_path, session: { email:       user.email,
+                                  password:    password,
+                                  remember_me: remember_me }
+    else
+      session[:user_id] = user.id
+    end
+  end
+
+  private
+
+    # Returns true inside an integration test.
+    # `post_via_redirect`メソッドが定義されていればインテグレーションテストとする
+    def integration_test?
+      defined?(post_via_redirect)
+    end
 end


### PR DESCRIPTION
佳境に入ってきました

---
- Index: #2
- Chapter 1: #6 
- Chapter 2: #7
- Chapter 3: #8 #10 
- Chapter 4: #11
- Chapter 5: #12 #14 
- Chapter 6: #17 #19 
- Chapter 7: #20 #21 
- Chapter 8: #22

---
- "This is a long and challenging chapter"
- HTTPはステートレスなので各リクエストは独立
  - そのHTTP上でユーザーのログインなどを実現するにはセッションを使う
  - セッションを実現するための手段として、RailsではCookieを使用
  - セッションもRESTfulなリソースとして表現できる
- というわけでSessionsコントローラーを作っていこう
  - `resources`メソッドのすべては使わないので、個別のrouteを作成
  - `GET /login`：newアクション→ログインページ
  - `POST /login`：createアクション→パスワード入力してログインする
  - `DELETE /login`：destroyアクション→ログアウトする
- ログインフォーム
  - Sessionsにはモデルがないので、どこにpostするか明示的に指定する必要がある
    - `form_for(:session, url: login_path)`
  - `params[:session][:email]`などで取得
  - →認証に必要な情報は`params[:session]`に入っている
  - `find_by(email:)`でメールアドレスからユーザーを検索
  - ユーザーが存在し、かつパスワードが正しければ認証OK
  - ActiveRecordモデルの場合はエラーメッセージをよしなにやってくれた
  - 今回はモデルじゃないので、自前でエラーメッセージを用意する
    - `flash[:danger] = '...'`
  - だが、このコードは少し正しくない
    - `render`メソッドは1リクエストにカウントされない＝エラーメッセージのあとにホームページへのリンクをクリックすると、またflashメッセージが表示されてしまう
- flashのテスト
  - 正しくないメール/パスワードでログイン試行したときのテスト
  - `flash.now`を使う
- ログイン
  - まず一時的なセッションでブラウザ終了するとログアウトするやつ
  - 次にブラウザ終了しても持続するやつ
- `log_in`メソッド
  - 一時的cookieを扱うには`session`メソッドを使う（さっき作ったSessionsコントローラーとは違うよ）
    - ハッシュのように扱える
    - `session[:user_id] = user.id`
    - ブラウザを終了するとすぐに期限切れになる
  - 永続cookieを扱うには`cookies`メソッドを使う
  - `session`メソッドで作られた一時cookieは自動的に暗号化される
- `current_user`メソッドを実装
  - sessionに保存されたuser_idをもとにDBからユーザー検索
  - `User.find(session[:user_id])`だとユーザーが存在しなかった場合例外が出るので
  - `User.find_by(id: session[:user_id])`を使う
  - 毎回DBアクセスしないようにインスタンス変数に保存する
    - `@current_user ||= User.find_by(id: session[:user_id])`
    - `||=`はよく使われるイディオム：@current_userがあればそれを返し、なければfindして代入
- レイアウトを変更
  - ログインしているか否かで表示を変えたい
  - `logged_in?`ヘルパーを実装して、ヘッダーのリンクで使う
  - ドロップダウンメニュー用にbootstrap JavaScriptを読み込む
    - `//= require bootstrap`
- テスト
  - fixturesをつくる
  - 環境に応じてハッシュ値の計算コストを変更する
    - 詳しく把握する必要はないと言っている
  - `has_secure_password`では仮想の`password`属性に生のパスワードを入れると、
    - 自動でハッシュ化して`password_digest`に保存してくれる
  - が、fixturesでは使えないので`password_digest`にハッシュ値を直接入れる
  - fixturesの呼び出し：`@user = users(:michael)`
- サインアップしたらログインしよう
  - `is_logged_in?`テストヘルパー
  - `logged_in?`ヘルパーと間違えないように名前を変えておく
- ログアウト
  - Sessionsコントローラーの`destroy`アクション
  - ログインの逆で、セッションからユーザーIDを削除する
    - `session.delete(:user_id)`
- リメンバーミー
  - remember tokenを`cookies`メソッドを使って作る
  - `sessions`は自動的にセキュアになるが、`cookies`はそうではない
  - 永続セッションはセッションハイジャック攻撃を受けやすい
    - remember tokenを攻撃者に盗まれるとそのユーザーとしてログインできてしまう
  - cookie盗聴手段は主に4つ
    1. パケットスニッファーを使う（安全でないネットワークにいるとき）
       - SSLを使うことで防げる
    2. remember tokenを含んだデータベース情報が漏洩する
       - トークン自身ではなくハッシュダイジェストを保存する（パスワードの保存と同じ）
    3. クロスサイトスクリプティング（XSS）攻撃を使う
       - Railsはデフォルトで自動的にエスケープする
    4. ログインしているユーザーのマシンに物理的にアクセスする
       - 完全に防ぐのは難しいが、ログアウトするたびにトークンを変更するなどで最小限にすることができる
- 以上のセキュリティを考慮すると、こんな感じに
  1. remember tokenとしてランダムな数字列を作成する
  2. 期限切れ日を遠い未来に設定したcookieにトークンを置く
  3. データベースにトークンのハッシュ値を保存
  4. ユーザーIDを暗号化してcookieに置く
  5. cookieに永続ユーザーIDがあったとき、そのIDでユーザーを検索し、remember tokenがDB上のハッシュ値と一致するか確認
- Remember meのトークンを保存する`remember_digest`カラムを追加
- `SecureRandom.urlsafe_base64`
  - 長いランダムな文字列がほしいときによく使う
- トークンを保存する
  - `has_secure_password`では自動でやっていたことを自分で書いていく
  - `remember_token`を仮想の属性として設定して、ハッシュ値を`remember_digest`としてDBに保存する
  - バリデーションをバイパスする`update_attribute`で更新する
    - パスワード確認なしで更新できるように
- リメンバーなログイン
  - `cookies.permanent[:remember_token] = remember_token`
    - permanentを使うと自動的に期限を20年後にセットしてくれる
  - `cookies.signed[:user_id] = user.id`
    - signedで暗号化する
  - トークンとハッシュ値を比較する
    - `BCrypt::Password.new(remember_digest).is_password?(remember_token)`
    - `==`は再定義されているので正しく動かない
  - これで覚えることはできたが、次は思い出す方
    - remember tokenを使って`current_user`メソッドを変更
  - ただ、このままじゃログアウトできない
- 忘れる
  - `forget`メソッドを作ってログアウト時にremember tokenを削除
- バグが2つ
  - 2つのウインドウを開いていて、1つでログアウトしてもう一方でもログアウトしたとき
    - ログインしているときのみログアウト処理する
  - 2つのブラウザでログインしていて、1つでログアウトしてもう一方でもログアウトしたとき
    - `remember_digest`がnilのときは何もしないでfalseを返す
- リメンバーミーのチェックボックスを作る
- テスト
  - `log_in_as`テストヘルパー
  - インテグレーションテストの場合は（通常のように）postすることでログインし、
  - そうでない場合はsessionメソッドを直接使ってログインとする
  - ハッシュはキーが存在しなければnilが返るので、`|| 'デフォルト値'`と書ける
  - テスト内ではキーにシンボルが使えないので、文字列でアクセスする
  - 思い出す方のテスト
    - `current_user`メソッドの「セッションはないけどremember cookieがある」状態がテストされていない
    - こういうとき、コードに`raise`を入れると、テストしてないならテストが通り、テストしてるなら例外が上がるので便利
  - SessionsHelperをテスト
    - fixturesからユーザーmichaelさんを作成
    - rememberメソッドで覚える
    - current_userメソッドで返ってくるユーザーがきちんとmichaelさんか確認
