### PR TITLE
Chapter 9 Updating, showing, and deleting users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'bcrypt', '~> 3.1.7'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'faker', '1.4.2'
+
 gem 'bootstrap-sass', '3.2.0.0'
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,8 @@ gem 'bcrypt', '~> 3.1.7'
 # gem 'capistrano-rails', group: :development
 
 gem 'faker', '1.4.2'
-
+gem 'will_paginate', '3.0.7'
+gem 'bootstrap-will_paginate', '0.0.10'
 gem 'bootstrap-sass', '3.2.0.0'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.0.1)
     execjs (2.7.0)
+    faker (1.4.2)
+      i18n (~> 0.5)
     ffi (1.9.10)
     formatador (0.2.5)
     globalid (0.3.6)
@@ -217,6 +219,7 @@ DEPENDENCIES
   bootstrap-sass (= 3.2.0.0)
   byebug
   coffee-rails (~> 4.1.0)
+  faker (= 1.4.2)
   guard-livereload
   guard-minitest (= 2.3.1)
   jbuilder (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.2.0.0)
       sass (~> 3.2)
+    bootstrap-will_paginate (0.0.10)
+      will_paginate
     builder (3.2.2)
     byebug (9.0.5)
     coderay (1.1.1)
@@ -210,6 +212,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    will_paginate (3.0.7)
 
 PLATFORMS
   ruby
@@ -217,6 +220,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootstrap-sass (= 3.2.0.0)
+  bootstrap-will_paginate (= 0.0.10)
   byebug
   coffee-rails (~> 4.1.0)
   faker (= 1.4.2)
@@ -239,6 +243,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate (= 3.0.7)
 
 BUNDLED WITH
    1.12.5

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -190,3 +190,15 @@ input {
   margin-top: 45px;
   @include box_sizing;
 }
+
+/* Users index */
+
+.users {
+  list-style: none;
+  margin: 0;
+  li {
+    overflow: auto;
+    padding: 10px 0;
+    border-bottom: 1px solid $gray-lighter;
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,8 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       log_in user
       params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      redirect_to user
+      # アクセスしようとしていたURLがあればそこへ、なければプロフィールページにリダイレクト
+      redirect_back_or user
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :correct_user,   only: [:edit, :update]
 
   def index
+    @users = User.all
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,15 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(user_params)
+      # Handle a successful update.
+    else
+      render 'edit'
+    end
+  end
+
   private
 
     def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,9 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update]
   before_action :correct_user,   only: [:edit, :update]
+
+  def index
+  end
 
   def show
     @user = User.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
   private
 
     def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :correct_user,   only: [:edit, :update]
 
   def index
-    @users = User.all
+    @users = User.paginate(page: params[:page])
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,8 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update_attributes(user_params)
-      # Handle a successful update.
+      flash[:success] = "Profile updated"
+      redirect_to @user
     else
       render 'edit'
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user,   only: [:edit, :update]
+  before_action :admin_user,     only: :destroy
 
   def index
     @users = User.paginate(page: params[:page])
@@ -39,6 +40,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    User.find(params[:id]).destroy
+    flash[:success] = "User deleted"
+    redirect_to users_url
+  end
+
   private
 
     def user_params
@@ -62,5 +69,10 @@ class UsersController < ApplicationController
       # params[:id]で指定されたユーザー(@user)が、現在ログイン中のユーザー(current_user)と一致しているか確認
       @user = User.find(params[:id])
       redirect_to(root_url) unless current_user?(@user)
+    end
+
+    # Confirms an admin user.
+    def admin_user
+      redirect_to(root_url) unless current_user.admin?
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :logged_in_user, only: [:edit, :update]
+  before_action :correct_user,   only: [:edit, :update]
 
   def show
     @user = User.find(params[:id])
@@ -48,5 +49,12 @@ class UsersController < ApplicationController
         flash[:danger] = "Please log in."
         redirect_to login_url
       end
+    end
+
+    # Confirms the correct user.
+    def correct_user
+      # params[:id]で指定されたユーザー(@user)が、現在ログイン中のユーザー(current_user)と一致しているか確認
+      @user = User.find(params[:id])
+      redirect_to(root_url) unless @user == current_user
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,6 +55,6 @@ class UsersController < ApplicationController
     def correct_user
       # params[:id]で指定されたユーザー(@user)が、現在ログイン中のユーザー(current_user)と一致しているか確認
       @user = User.find(params[:id])
-      redirect_to(root_url) unless @user == current_user
+      redirect_to(root_url) unless current_user?(@user)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
+
   def show
     @user = User.find(params[:id])
   end
@@ -37,5 +39,14 @@ class UsersController < ApplicationController
     def user_params
       params.require(:user).permit(:name, :email, :password,
                                    :password_confirmation)
+    end
+
+    # Before filters
+    # Confirms a logged-in user.
+    def logged_in_user
+      unless logged_in?
+        flash[:danger] = "Please log in."
+        redirect_to login_url
+      end
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,6 +46,8 @@ class UsersController < ApplicationController
     # Confirms a logged-in user.
     def logged_in_user
       unless logged_in?
+        # アクセスしようとしていたURLを保存し、ログインページにリダイレクト
+        store_location
         flash[:danger] = "Please log in."
         redirect_to login_url
       end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -11,6 +11,11 @@ module SessionsHelper
     cookies.permanent[:remember_token] = user.remember_token
   end
 
+  # Returns true if the given user is the current user.
+  def current_user?(user)
+    user == current_user
+  end
+
   # Returns the user corresponding to the remember token cookie.
   def current_user
     if (user_id = session[:user_id])

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -47,4 +47,17 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
+
+  # Redirects to stored location (or to the default).
+  # セッションに保存されているForwarding URLにリダイレクト
+  def redirect_back_or(default)
+    redirect_to(session[:forwarding_url] || default)
+    session.delete(:forwarding_url)
+  end
+
+  # Stores the URL trying to be accessed.
+  # アクセスしようとしていたURLをセッションに保存
+  def store_location
+    session[:forwarding_url] = request.url if request.get?
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,8 +1,9 @@
 module UsersHelper
   # Returns the Gravatar for the given user.
-  def gravatar_for(user)
+  def gravatar_for(user, options = { size: 80 })
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    size = options[:size]
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: "gravatar")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ActiveRecord::Base
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   # Returns the hash digest of the given string.
   def User.digest(string)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
             </a>
             <ul class="dropdown-menu">
               <li><%= link_to "Profile", current_user %></li>
-              <li><%= link_to "Settings", '#' %></li>
+              <li><%= link_to "Settings", edit_user_path(current_user) %></li>
               <li class="divider"></li>
               <li>
                 <%= link_to "Log out", logout_path, method: "delete" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,7 +6,7 @@
         <li><%= link_to "Home", root_path %></li>
         <li><%= link_to "Help", help_path %></li>
         <% if logged_in? %>
-          <li><%= link_to "Users", '#' %></li>
+          <li><%= link_to "Users", users_path %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               Account <b class="caret"></b>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,4 @@
+<li>
+  <%= gravatar_for user, size: 50 %>
+  <%= link_to user.name, user %>
+</li>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,4 +1,9 @@
 <li>
   <%= gravatar_for user, size: 50 %>
   <%= link_to user.name, user %>
+  <%# ログインユーザーがadminで、かつ本人のアカウント以外であれば削除リンクを表示する %>
+  <% if current_user.admin? && !current_user?(user) %>
+    | <%= link_to "delete", user, method: :delete,
+                                  data: { confirm: "You sure?" } %>
+  <% end %>
 </li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,29 @@
+<% provide(:title, "Edit user") %>
+<h1>Update your profile</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control' %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Save changes", class: "btn btn-primary" %>
+    <% end %>
+
+    <div class="gravatar_edit">
+      <%= gravatar_for @user %>
+      <a href="http://gravatar.com/emails" target="_blank">change</a>
+    </div>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,8 @@
 <% provide(:title, 'All users') %>
 <h1>All users</h1>
 
+<%= will_paginate %>
+
 <ul class="users">
   <% @users.each do |user| %>
     <li>
@@ -9,3 +11,5 @@
     </li>
   <% end %>
 </ul>
+
+<%= will_paginate %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,11 @@
+<% provide(:title, 'All users') %>
+<h1>All users</h1>
+
+<ul class="users">
+  <% @users.each do |user| %>
+    <li>
+      <%= gravatar_for user, size: 50 %>
+      <%= link_to user.name, user %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,12 +4,8 @@
 <%= will_paginate %>
 
 <ul class="users">
-  <% @users.each do |user| %>
-    <li>
-      <%= gravatar_for user, size: 50 %>
-      <%= link_to user.name, user %>
-    </li>
-  <% end %>
+  <%# renderメソッドにARオブジェクトを渡すと、自動的に対応するパーシャルを探してイテレートしてレンダリングしてくれる %>
+  <%= render @users %>
 </ul>
 
 <%= will_paginate %>

--- a/db/migrate/20160704023336_add_admin_to_users.rb
+++ b/db/migrate/20160704023336_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160629062802) do
+ActiveRecord::Schema.define(version: 20160704023336) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "password_digest"
     t.string   "remember_digest"
+    t.boolean  "admin",           default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,8 @@
 User.create!(name:  "Example User",
              email: "example@railstutorial.org",
              password:              "foobar",
-             password_confirmation: "foobar")
+             password_confirmation: "foobar",
+             admin: true)
 
 99.times do |n|
   name  = Faker::Name.name

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,18 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+User.create!(name:  "Example User",
+             email: "example@railstutorial.org",
+             password:              "foobar",
+             password_confirmation: "foobar")
+
+99.times do |n|
+  name  = Faker::Name.name
+  email = "example-#{n+1}@railstutorial.org"
+  password = "password"
+  User.create!(name:  name,
+               email: email,
+               password:              password,
+               password_confirmation: password)
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -6,6 +6,11 @@ class UsersControllerTest < ActionController::TestCase
     @other_user = users(:archer)
   end
 
+  test "should redirect index when not logged in" do
+    get :index
+    assert_redirected_to login_url
+  end
+
   test "should get new" do
     get :new
     assert_response :success

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,9 +1,25 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
+  def setup
+    @user = users(:michael)
+  end
+
   test "should get new" do
     get :new
     assert_response :success
   end
 
+  # ログインしていないときはログインページにリダイレクトすること
+  test "should redirect edit when not logged in" do
+    get :edit, id: @user
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
+
+  test "should redirect update when not logged in" do
+    patch :update, id: @user, user: { name: @user.name, email: @user.email }
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -43,4 +43,21 @@ class UsersControllerTest < ActionController::TestCase
     assert flash.empty?
     assert_redirected_to root_url
   end
+
+  # ログインしていない場合はユーザーを削除せずリダイレクトすること
+  test "should redirect destroy when not logged in" do
+    assert_no_difference 'User.count' do
+      delete :destroy, id: @user
+    end
+    assert_redirected_to login_url
+  end
+
+  # ログインしているがadminではないときも、ユーザーを削除せずリダイレクトすること
+  test "should redirect destroy when logged in as a non-admin" do
+    log_in_as(@other_user)
+    assert_no_difference 'User.count' do
+      delete :destroy, id: @user
+    end
+    assert_redirected_to root_url
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class UsersControllerTest < ActionController::TestCase
   def setup
     @user = users(:michael)
+    @other_user = users(:archer)
   end
 
   test "should get new" do
@@ -21,5 +22,20 @@ class UsersControllerTest < ActionController::TestCase
     patch :update, id: @user, user: { name: @user.name, email: @user.email }
     assert_not flash.empty?
     assert_redirected_to login_url
+  end
+
+  # ログインしている本人以外はプロフィールを編集できないこと
+  test "should redirect edit when logged in as wrong user" do
+    log_in_as(@other_user)
+    get :edit, id: @user
+    assert flash.empty?
+    assert_redirected_to root_url
+  end
+
+  test "should redirect update when logged in as wrong user" do
+    log_in_as(@other_user)
+    patch :update, id: @user, user: { name: @user.name, email: @user.email }
+    assert flash.empty?
+    assert_redirected_to root_url
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,7 @@ michael:
   name: Michael Example
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
+  admin: true
 
 archer:
   name: Sterling Archer

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,3 +4,8 @@ michael:
   name: Michael Example
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
+
+archer:
+  name: Sterling Archer
+  email: duchess@example.gov
+  password_digest: <%= User.digest('password') %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -9,3 +9,20 @@ archer:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+
+lana:
+  name: Lana Kane
+  email: hands@example.gov
+  password_digest: <%= User.digest('password') %>
+
+malory:
+  name: Malory Archer
+  email: boss@example.gov
+  password_digest: <%= User.digest('password') %>
+
+<% 30.times do |n| %>
+user_<%= n %>:
+  name:  <%= "User #{n}" %>
+  email: <%= "user-#{n}@example.com" %>
+  password_digest: <%= User.digest('password') %>
+<% end %>

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -17,10 +17,11 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     assert_template 'users/edit'
   end
 
-  test "successful edit" do
-    log_in_as(@user)
+  test "successful edit with friendly forwarding" do
     get edit_user_path(@user)
-    assert_template 'users/edit'
+    log_in_as(@user)
+    # ログイン前にアクセスしようとしていたページ(edit_user_path)にリダイレクトされること
+    assert_redirected_to edit_user_path(@user)
     name  = "Foo Bar"
     email = "foo@bar.com"
     patch user_path(@user), user: { name:  name,

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -6,6 +6,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
   end
 
   test "unsuccessful edit" do
+    log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     # user_pathにPATCHリクエスト→編集
@@ -17,6 +18,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
   end
 
   test "successful edit" do
+    log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     name  = "Foo Bar"

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class UsersEditTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
+  test "unsuccessful edit" do
+    get edit_user_path(@user)
+    assert_template 'users/edit'
+    # user_pathにPATCHリクエスト→編集
+    patch user_path(@user), user: { name:  "",
+                                    email: "foo@invalid",
+                                    password:              "foo",
+                                    password_confirmation: "bar" }
+    assert_template 'users/edit'
+  end
+end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -15,4 +15,21 @@ class UsersEditTest < ActionDispatch::IntegrationTest
                                     password_confirmation: "bar" }
     assert_template 'users/edit'
   end
+
+  test "successful edit" do
+    get edit_user_path(@user)
+    assert_template 'users/edit'
+    name  = "Foo Bar"
+    email = "foo@bar.com"
+    patch user_path(@user), user: { name:  name,
+                                    email: email,
+                                    password:              "",
+                                    password_confirmation: "" }
+    assert_not flash.empty?
+    assert_redirected_to @user
+    # @userをDBから読み込み直し、DBの値が確実に更新されていることを確認
+    @user.reload
+    assert_equal name,  @user.name
+    assert_equal email, @user.email
+  end
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class UsersIndexTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
+  test "index including pagination" do
+    log_in_as(@user)
+    # ユーザー一覧ページにアクセス
+    get users_path
+    assert_template 'users/index'
+    assert_select 'div.pagination'
+    # `User.paginate`で返されるユーザーが、表示されたページと一致していること
+    User.paginate(page: 1).each do |user|
+      assert_select 'a[href=?]', user_path(user), text: user.name
+    end
+  end
+end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -2,18 +2,36 @@ require 'test_helper'
 
 class UsersIndexTest < ActionDispatch::IntegrationTest
   def setup
-    @user = users(:michael)
+    @admin     = users(:michael)
+    @non_admin = users(:archer)
   end
 
-  test "index including pagination" do
-    log_in_as(@user)
+  # ページネーションと削除リンクのテスト
+  test "index as admin including pagination and delete links" do
+    log_in_as(@admin)
     # ユーザー一覧ページにアクセス
     get users_path
     assert_template 'users/index'
     assert_select 'div.pagination'
     # `User.paginate`で返されるユーザーが、表示されたページと一致していること
-    User.paginate(page: 1).each do |user|
+    first_page_of_users = User.paginate(page: 1)
+    first_page_of_users.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.name
+      # 本人のアカウント以外には削除リンクが表示されること
+      unless user == @admin
+        assert_select 'a[href=?]', user_path(user), text: 'delete'
+      end
     end
+    # adminはユーザーを削除できること
+    assert_difference 'User.count', -1 do
+      delete user_path(@non_admin)
+    end
+  end
+
+  # adminではない場合、ユーザー削除リンクが表示されないこと
+  test "index as non-admin" do
+    log_in_as(@non_admin)
+    get users_path
+    assert_select 'a', text: 'delete', count: 0
   end
 end


### PR DESCRIPTION
やっと9章だ……！

---
- Index: #2
- Chapter 1: #6 
- Chapter 2: #7
- Chapter 3: #8 #10 
- Chapter 4: #11
- Chapter 5: #12 #14 
- Chapter 6: #17 #19 
- Chapter 7: #20 #21 
- Chapter 8: #22 #23 
- Chapter 9: #24 

---
- プロフィールをフォームから編集できるように：PATCHリクエスト→updateアクション
- strongparameter
- `before_action`フィルター
- friendly forward
- `db/seeds.rb`を`rake db:seed`で読み込む
- `render @users`
  - renderメソッドにARオブジェクトを渡すと、自動的に対応するパーシャルを探してイテレートしてレンダリングしてくれる
- admin属性作って、adminのみユーザーを削除可能に
