### PR TITLE
Chapter 9 Exercises

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_for(@user) do |f| %>
+  <%= render 'shared/error_messages', object: @user %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name, class: 'form-control' %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email, class: 'form-control' %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password, class: 'form-control' %>
+
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,26 +1,10 @@
 <% provide(:title, "Edit user") %>
+<% provide(:button_text, "Save changes") %>
 <h1>Update your profile</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
-      <%= f.submit "Save changes", class: "btn btn-primary" %>
-    <% end %>
-
+    <%= render 'form' %>
     <div class="gravatar_edit">
       <%= gravatar_for @user %>
       <a href="http://gravatar.com/emails" target="_blank">change</a>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,24 +1,9 @@
 <% provide(:title, 'Sign up') %>
+<% provide(:button_text, 'Create my account') %>
 <h1>Sign up</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
-      <%= f.submit "Create my account", class: "btn btn-primary" %>
-    <% end %>
+    <%= render 'form' %>
   </div>
 </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -44,6 +44,16 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to root_url
   end
 
+  # admin属性はWebから更新できないこと
+  test "should not allow the admin attribute to be edited via the web" do
+    log_in_as(@other_user)
+    assert_not @other_user.admin?
+    patch :update, id: @other_user, user: { password:              "password",
+                                            password_confirmation: "password",
+                                            admin: true }
+    assert_not @other_user.reload.admin?
+  end
+
   # ログインしていない場合はユーザーを削除せずリダイレクトすること
   test "should redirect destroy when not logged in" do
     assert_no_difference 'User.count' do

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class SiteLayoutTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
   test "layout links" do
     get root_path
     assert_template 'static_pages/home'
@@ -8,5 +12,31 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", help_path
     assert_select "a[href=?]", about_path
     assert_select "a[href=?]", contact_path
+  end
+
+  # ログイン・ログアウトで変わるリンクのテスト
+  # ログインしていないとき
+  test "layout links for non-logged-in users" do
+    get root_path
+    # 表示するもの
+    assert_select "a[href=?]", login_path
+    # 表示しないもの
+    assert_select "a[href=?]", users_path, count: 0 # ユーザー一覧
+    assert_select "a[href=?]", user_path(@user), count: 0 # プロフィール
+    assert_select "a[href=?]", edit_user_path(@user), count: 0 # 設定
+    assert_select "a[href=?]", logout_path, count: 0 # ログアウト
+  end
+
+  # ログインしているとき
+  test "layout links for logged-in users" do
+    log_in_as(@user)
+    get root_path
+    # 表示するもの
+    assert_select "a[href=?]", users_path # ユーザー一覧
+    assert_select "a[href=?]", user_path(@user) # プロフィール
+    assert_select "a[href=?]", edit_user_path(@user) # 設定
+    assert_select "a[href=?]", logout_path # ログアウト
+    # 表示しないもの
+    assert_select "a[href=?]", login_path, count: 0
   end
 end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -19,9 +19,13 @@ class UsersEditTest < ActionDispatch::IntegrationTest
 
   test "successful edit with friendly forwarding" do
     get edit_user_path(@user)
+    # session[:forwarding_url]に転送先のURLが正しく入っていること
+    assert_equal edit_user_url(@user), session[:forwarding_url]
     log_in_as(@user)
     # ログイン前にアクセスしようとしていたページ(edit_user_path)にリダイレクトされること
     assert_redirected_to edit_user_path(@user)
+    # session[:forwarding_url]が削除されていること
+    assert session[:forwarding_url].nil?
     name  = "Foo Bar"
     email = "foo@bar.com"
     patch user_path(@user), user: { name:  name,

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -25,7 +25,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     # ログイン前にアクセスしようとしていたページ(edit_user_path)にリダイレクトされること
     assert_redirected_to edit_user_path(@user)
     # session[:forwarding_url]が削除されていること
-    assert session[:forwarding_url].nil?
+    assert_nil session[:forwarding_url]
     name  = "Foo Bar"
     email = "foo@bar.com"
     patch user_path(@user), user: { name:  name,


### PR DESCRIPTION
http://3rd-edition.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises
1. friendly forwardingで、与えられたURLに1回のみ転送することを確認するテストを書け（もう一度ログインしたときにはデフォルトページに転送されるべき）
2. ログイン・ログアウト時それぞれで、レイアウトリンクが適切な振る舞いをするかを確認するインテグレーションテストを書け
3. admin属性がWebから更新できないことを直接PATCHリクエストを送るテストを書いて確認せよ。このとき、Strongparameter（user_params）に:adminを追加したらテストが失敗する→外すと通る、の順でやる
4. new、editビューを例のようにパーシャルを使ってリファクタして、重複したフォームを削除せよ
