### PR TITLE
Chapter 10 Exercises

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,12 @@ class UsersController < ApplicationController
   before_action :admin_user,     only: :destroy
 
   def index
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,8 +44,7 @@ class User < ActiveRecord::Base
 
   # Activates an account.
   def activate
-    update_attribute(:activated,    true)
-    update_attribute(:activated_at, Time.zone.now)
+    update_columns(activated: true, activated_at: Time.zone.now)
   end
 
   # Sends activation email.
@@ -57,8 +56,8 @@ class User < ActiveRecord::Base
   # Sets the password reset attributes.
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attribute(:reset_digest,  User.digest(reset_token))
-    update_attribute(:reset_sent_at, Time.zone.now)
+    update_columns(reset_digest:  User.digest(reset_token),
+                   reset_sent_at: Time.zone.now)
   end
 
   # Sends password reset email.

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -17,8 +17,8 @@ class UsersControllerTest < ActionController::TestCase
     log_in_as(@user)
     get :index
     index_users = assigns(:users)
-    assert index_users.include?(@user)
-    assert_not index_users.include?(@inactive_user)
+    assert_includes(index_users, @user)
+    assert_not_includes(index_users, @inactive_user)
   end
 
   # ユーザーがアクティベートされていないときは、トップページにリダイレクトすること

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -4,11 +4,29 @@ class UsersControllerTest < ActionController::TestCase
   def setup
     @user = users(:michael)
     @other_user = users(:archer)
+    @inactive_user = users(:inactive)
   end
 
   test "should redirect index when not logged in" do
     get :index
     assert_redirected_to login_url
+  end
+
+  # アクティベートされていないユーザーはindexに含まないこと
+  test "should not include inactive user" do
+    log_in_as(@user)
+    get :index
+    index_users = assigns(:users)
+    assert index_users.include?(@user)
+    assert_not index_users.include?(@inactive_user)
+  end
+
+  # ユーザーがアクティベートされていないときは、トップページにリダイレクトすること
+  test "should redirect show when inactive user" do
+    get :show, id: @user
+    assert_response :success
+    get :show, id: @inactive_user
+    assert_redirected_to root_url
   end
 
   test "should get new" do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -29,6 +29,12 @@ malory:
   activated: true
   activated_at: <%= Time.zone.now %>
 
+inactive:
+  name: Inactive User
+  email: inactive@example.com
+  password_digest: <%= User.digest('password') %>
+  activated: false
+
 <% 30.times do |n| %>
 user_<%= n %>:
   name:  <%= "User #{n}" %>

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -66,4 +66,21 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     assert_redirected_to user
   end
+
+  test "expired token" do
+    get new_password_reset_path
+    post password_resets_path, password_reset: { email: @user.email }
+
+    @user = assigns(:user)
+    # リセットメール送信時刻を3時間前にセット（期限切れは2時間）
+    @user.update_attribute(:reset_sent_at, 3.hours.ago)
+    patch password_reset_path(@user.reset_token),
+          email: @user.email,
+          user: { password:              "foobar",
+                  password_confirmation: "foobar" }
+    assert_response :redirect
+    follow_redirect!
+    # レスポンスボディ(ページのHTML)に"expired"が含まれていること
+    assert_match /expired/i, response.body
+  end
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -14,7 +14,7 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     assert_template 'users/index'
     assert_select 'div.pagination'
     # `User.paginate`で返されるユーザーが、表示されたページと一致していること
-    first_page_of_users = User.paginate(page: 1)
+    first_page_of_users = User.where(activated: true).paginate(page: 1)
     first_page_of_users.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.name
       # 本人のアカウント以外には削除リンクが表示されること


### PR DESCRIPTION
http://3rd-edition.railstutorial.org/book/account_activation_password_reset#sec-activation_resets_exercises
1. パスワードリセットで、トークンが2時間の期限切れになっている場合のインテグレーションテストを書け
   - `test/integration/password_resets_test.rb`に、10.57の例を参考にして書く
   - `response.body`はそのページのHTML bodyを返す
   - テストする方法はいろいろあるけど、今回は10.57のようにレスポンスボディに “expired”というワードが含まれているかを確認する
2. 今はすべてのユーザーがuser indexページ(/users)に表示され、 /users/:idで個々のユーザーを表示できる。しかしそれは彼らがアクティベートされている場合に限り意味をなす。10.58のようにUsersコントローラーを変更し、アクティベートされたユーザーのみ表示するようにせよ
   - Extra credit: このときの/usersと/users:idのインテグレーションテストを書いてみよう
3. 10.42（Userモデル）のcreate_reset_digest、activateメソッドでは2回update_attributeメソッドを呼んでいるが、これだとDBトランザクションが分離してしまう。10.59のようにupdate_columnsメソッドに変更してトランザクションを1回で済ませ、この状態でテストが通ることを確認せよ
